### PR TITLE
Allow the array passed to `or` to contain anything that is a valid vlad schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - '0.10'
-    - '0.12'
     - '4.2'
     - '5.5'
 install: 'npm install'

--- a/src/vlad.js
+++ b/src/vlad.js
@@ -153,11 +153,14 @@ vlad.equals = promiseWrapper.equals = function vlad$equals(value, message) {
 
 vlad.or = promiseWrapper.or = function vlad$or(arr) {
   var prop = new Property();
+  var vladArr = arr.map(v => {
+    return vlad(v);
+  });
 
   prop.validate = function(val) {
       var lastErr = new error.FieldValidationError('Invalid value.');
-      for (var i = 0; i < arr.length; i++) {
-          var result = util.safeCall(arr[i], val);
+      for (var i = 0; i < vladArr.length; i++) {
+          var result = util.safeCall(vladArr[i], val);
           if (result instanceof error.ValidationError) lastErr = result;
           else return result;
       }

--- a/test/or-test.js
+++ b/test/or-test.js
@@ -26,6 +26,7 @@ describe('or validation', function() {
         }
     ]));
 
+
     it('should attempt the first possibility first', function() {
         return validate('1').then(val => {
             expect(val).to.equal(1);
@@ -78,5 +79,15 @@ describe('or validation', function() {
       return validateMixedFunc('BAR').then(val => {
           expect(val).to.equal('FOO! BAR');
       });
+    });
+
+    it('should throw a schema error if or is passed an invalid vlad object', function() {
+      try {
+        var invalidOr = vlad(vlad.or([
+          1
+        ]));
+      } catch (e) {
+        expect(e.message).to.equal('Invalid schema.')
+      }
     });
 });

--- a/test/or-test.js
+++ b/test/or-test.js
@@ -5,6 +5,27 @@ describe('or validation', function() {
         vlad.sync(vlad.string)
     ]));
 
+    var validateProperties = vlad(vlad.or([
+        vlad.boolean,
+        vlad.number
+    ]));
+
+    var validateMixed = vlad(vlad.or([
+        vlad.number,
+        vlad.sync(vlad.string)
+    ]));
+
+    var validateMixedFunc = vlad(vlad.or([
+        vlad.number,
+        function(val) {
+          if (!typeof val === 'string') {
+            throw new Error('Bad style foo error');
+          }
+
+          return 'FOO! ' + val
+        }
+    ]));
+
     it('should attempt the first possibility first', function() {
         return validate('1').then(val => {
             expect(val).to.equal(1);
@@ -21,5 +42,41 @@ describe('or validation', function() {
       return validate({}).catch(err => {
           expect(err.message).to.equal('[object Object] is not a string');
       });
-    })
+    });
+
+    it('should validate properties', function() {
+      return validateProperties({}).catch(err => {
+          expect(err.message).to.equal('[object Object] is not a number.');
+      });
+    });
+
+    it('should validate properties and return correctly', function() {
+      return validateProperties(1).then(val => {
+          expect(val).to.equal(1);
+      });
+    });
+
+    it('should allow mixture of properties and functions', function() {
+      return validateMixed({}).catch(err => {
+          expect(err.message).to.equal('[object Object] is not a string');
+      });
+    });
+
+    it('should allow mixture of properties and functions and return a correct value', function() {
+      return validateMixed('foo').then(val => {
+          expect(val).to.equal('foo');
+      });
+    });
+
+    it('should return the last error message with mixed arrays', function() {
+      return validateMixedFunc({}).catch(err => {
+          expect(err.message).to.equal('Bad style foo error');
+      });
+    });
+
+    it('should return the correct value from inline functions', function() {
+      return validateMixedFunc('BAR').then(val => {
+          expect(val).to.equal('FOO! BAR');
+      });
+    });
 });


### PR DESCRIPTION
Also removed node .10 and .12 from the .travis since this library uses fat arrow functions